### PR TITLE
Stop building Docker image on non-prod branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,6 +173,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     needs: [playwright, hadolint, phpcs, phpstan, phpunit]
+    if: github.ref == 'refs/heads/prod'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
We only need the Docker image for deployment, so it slows down quality checks on PRs.